### PR TITLE
Improve scan support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *~
 *.pyc
+build/
+dist/
+*.egg-info/

--- a/examples/pyhbase-cli
+++ b/examples/pyhbase-cli
@@ -165,7 +165,7 @@ if __name__=="__main__":
     if len(args) != 2:
       usage()
       sys.exit(1)
-    print connection.scan(*args)
+    pprint.pprint(connection.scan(args[0], args[1]))
   elif cmd == 'delete':
     if len(args) < 2:
       usage()

--- a/pyhbase/connection.py
+++ b/pyhbase/connection.py
@@ -205,7 +205,7 @@ class HBaseConnection(object):
   # TODO(hammer): Figure out cleaner, more functional command-line
   @retry_wrapper
   def scan(self, table, number_of_rows, start_row=None,
-           stop_row=None, columns=[], timestamp=None):
+           stop_row=None, columns=None, timestamp=None):
 
     if columns:
       columns = [{"family": column[0], "qualifier": column[1]}


### PR DESCRIPTION
`scan()` now supports parameters like start row, stop row, and columns.

The CLI still needs to be reworked, but the existing functionality is left intact.
