### PR TITLE
Use functools.wraps to preserve metadata

### DIFF
--- a/pyhbase/connection.py
+++ b/pyhbase/connection.py
@@ -1,3 +1,4 @@
+import functools
 import os
 import sys
 
@@ -10,6 +11,7 @@ PROTOCOL = protocol.parse(open(PROTO_FILE).read())
 
 def retry_wrapper(fn):
   """a decorator to add retry symantics to any method that uses hbase"""
+  @functools.wraps(fn)
   def f(self, *args, **kwargs):
     try:
       return fn(self, *args, **kwargs)


### PR DESCRIPTION
A little bit random, but while playing around with pyhbase I noticed the docstrings are getting confused because of the retry_wrapper decorator.  functools.wraps forwards this metadata information into the wrapper function.
